### PR TITLE
Update to hadoop 2.7.7 and Spark 3.0.0

### DIFF
--- a/big_data_deployer/hadoop.py
+++ b/big_data_deployer/hadoop.py
@@ -139,3 +139,4 @@ class HadoopFramework(Framework):
 
 get_framework_registry().register_framework(HadoopFramework())
 get_framework_registry().framework("hadoop").add_version(HadoopFrameworkVersion("2.6.0", "https://archive.apache.org/dist/hadoop/core/hadoop-2.6.0/hadoop-2.6.0.tar.gz", "tar.gz", "hadoop-2.6.0", "2.6.x"))
+get_framework_registry().framework("hadoop").add_version(HadoopFrameworkVersion("2.7.7", "https://archive.apache.org/dist/hadoop/core/hadoop-2.7.7/hadoop-2.7.7.tar.gz", "tar.gz", "hadoop-2.7.7", "2.6.x"))

--- a/big_data_deployer/spark.py
+++ b/big_data_deployer/spark.py
@@ -104,3 +104,4 @@ class SparkFramework(Framework):
 
 get_framework_registry().register_framework(SparkFramework())
 get_framework_registry().framework("spark").add_version(SparkFrameworkVersion("2.4.0", "https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.6.tgz", "tgz", "spark-2.4.0-bin-hadoop2.6", "2.4.x"))
+get_framework_registry().framework("spark").add_version(SparkFrameworkVersion("3.0.0", "https://archive.apache.org/dist/spark/spark-3.0.0/spark-3.0.0-bin-hadoop2.7.tgz", "tgz", "spark-3.0.0-bin-hadoop2.7", "2.4.x"))


### PR DESCRIPTION
The performance gains don't lie! We must use spark 3.0! https://databricks.com/blog/2020/06/18/introducing-apache-spark-3-0-now-available-in-databricks-runtime-7-0.html